### PR TITLE
Prefer serde to rustc-serialize

### DIFF
--- a/src/charsheet/Cargo.toml
+++ b/src/charsheet/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Quinten Palmer <quintenpalmer@gmail.com>"]
 
 [dependencies]
 libpathfinder = {path = "../libpathfinder"}
-rustc-serialize = "0.3.23"
+serde_json = "1.0.0"

--- a/src/charsheet/src/main.rs
+++ b/src/charsheet/src/main.rs
@@ -1,7 +1,5 @@
 extern crate libpathfinder as libpf;
-extern crate rustc_serialize;
-
-use rustc_serialize::json;
+extern crate serde_json;
 
 use libpf::models;
 
@@ -15,6 +13,6 @@ fn main() {
 fn run_app() -> Result<(), models::Error> {
     let c = models::Character::new("Idrigoth".to_string());
     println!("character: {}",
-             try!(json::encode(&c).map_err(models::Error::Json)));
+             try!(serde_json::to_string(&c).map_err(models::Error::Json)));
     return Ok(());
 }

--- a/src/libpathfinder/Cargo.toml
+++ b/src/libpathfinder/Cargo.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 authors = ["Quinten Palmer <quintenpalmer@gmail.com>"]
 
 [dependencies]
-rustc-serialize = "0.3.23"
+serde = "1.0.0"
+serde_json = "1.0.0"
+serde_derive = "1.0.0"

--- a/src/libpathfinder/src/lib.rs
+++ b/src/libpathfinder/src/lib.rs
@@ -1,3 +1,6 @@
-extern crate rustc_serialize;
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
 pub mod models;

--- a/src/libpathfinder/src/models.rs
+++ b/src/libpathfinder/src/models.rs
@@ -1,6 +1,6 @@
-use rustc_serialize::json;
+use serde_json;
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Serialize, Deserialize)]
 pub struct Character {
     name: String,
 }
@@ -13,5 +13,5 @@ impl Character {
 
 #[derive(Debug)]
 pub enum Error {
-    Json(json::EncoderError),
+    Json(serde_json::Error),
 }

--- a/src/pathserver/Cargo.toml
+++ b/src/pathserver/Cargo.toml
@@ -7,4 +7,6 @@ authors = ["Quinten Palmer <quintenpalmer@gmail.com>"]
 libpathfinder = {path = "../libpathfinder"}
 iron = "0.5.1"
 urlencoded = "0.5.0"
-rustc-serialize = "0.3.23"
+serde = "1.0.0"
+serde_json = "1.0.0"
+serde_derive = "1.0.0"

--- a/src/pathserver/src/main.rs
+++ b/src/pathserver/src/main.rs
@@ -1,5 +1,8 @@
 extern crate libpathfinder as libpf;
-extern crate rustc_serialize;
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 #[macro_use]
 extern crate iron;
 extern crate urlencoded;

--- a/src/pathserver/src/webshared.rs
+++ b/src/pathserver/src/webshared.rs
@@ -1,17 +1,17 @@
-use rustc_serialize;
-use rustc_serialize::json;
+use serde;
+use serde_json;
 
 use iron;
 use iron::status;
 
-#[derive(RustcDecodable, RustcEncodable)]
-pub struct Response<T: rustc_serialize::Encodable> {
+#[derive(Serialize, Deserialize)]
+pub struct Response<T: serde::Serialize> {
     pub data: T,
 }
 
-impl<T: rustc_serialize::Encodable> Response<T> {
+impl<T: serde::Serialize> Response<T> {
     pub fn encode(&self) -> iron::IronResult<iron::Response> {
-        let msg = itry!(json::encode(self),
+        let msg = itry!(serde_json::to_string(self),
                         server_error("could not encode json response".to_owned()));
 
         println!("responding with: {}", msg);
@@ -21,8 +21,8 @@ impl<T: rustc_serialize::Encodable> Response<T> {
     }
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
-pub struct ErrMessage<T: rustc_serialize::Encodable> {
+#[derive(Serialize, Deserialize)]
+pub struct ErrMessage<T: serde::Serialize> {
     pub error: T,
 }
 
@@ -35,6 +35,6 @@ pub fn bad_request(msg: String) -> (status::Status, String) {
 }
 
 fn status_message(s: status::Status, msg: String) -> (status::Status, String) {
-    let json_msg = json::encode(&ErrMessage { error: msg }).unwrap();
+    let json_msg = serde_json::to_string(&ErrMessage { error: msg }).unwrap();
     return (s, json_msg);
 }


### PR DESCRIPTION
With serde reaching 1.0.0 and this notice:

https://github.com/rust-lang-deprecated/rustc-serialize/tree/0b789cfcb2474f2b6f5bb2fc9d55cc838c0025cf#rustc-serialize

Preferring serde for this project going forward.