### PR TITLE
Remove charsheet from top level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 members = [
   "src/libpathfinder/",
-  "src/charsheet/",
   "src/pathserver/",
 ]


### PR DESCRIPTION
Without this change cargo complains that it can't find this cargo file,
which it has been told does exist.