### PR TITLE
Derive macro for FromDB for arbitrary structs

### DIFF
--- a/src/libpathfinder/src/datastore/mod.rs
+++ b/src/libpathfinder/src/datastore/mod.rs
@@ -2,6 +2,8 @@ use std::path;
 
 use rusqlite;
 
+use libpathfinder_common::FromDB;
+
 use libpathfinder_common::error::Error;
 use models;
 
@@ -16,11 +18,6 @@ impl Datastore {
     }
 
     pub fn get_character(&self, id: u32) -> Result<models::Character, Error> {
-        let mut stmt = self.conn.prepare("SELECT id, name FROM characters WHERE id = ?1").unwrap();
-        let character =
-            try!(stmt.query_row(&[&id], |row| models::Character::new(row.get(0), row.get(1)))
-                .map_err(Error::Rusqlite));
-
-        return Ok(character);
+        models::Character::select_one(&self.conn, id)
     }
 }

--- a/src/libpathfinder/src/models.rs
+++ b/src/libpathfinder/src/models.rs
@@ -1,4 +1,8 @@
-#[derive(Serialize, Deserialize)]
+use rusqlite;
+use libpathfinder_common::error;
+
+#[derive(Serialize, Deserialize, FromDB)]
+#[from_db(table_name = "characters")]
 pub struct Character {
     id: u32,
     name: String,

--- a/src/libpathfinder_common/src/lib.rs
+++ b/src/libpathfinder_common/src/lib.rs
@@ -12,3 +12,8 @@ pub mod webshared;
 pub trait QueryParam {
     fn parse_from(&mut iron::Request) -> iron::IronResult<Self> where Self: Sized;
 }
+
+pub trait FromDB {
+    fn select_one(conn: &rusqlite::Connection, id: u32) -> Result<Self, error::Error>
+        where Self: Sized;
+}

--- a/src/libpathfinder_derive/src/lib.rs
+++ b/src/libpathfinder_derive/src/lib.rs
@@ -8,6 +8,9 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
+use syn::MetaItem::{List, NameValue};
+use syn::NestedMetaItem::MetaItem;
+
 #[proc_macro_derive(QueryParam)]
 pub fn query_param_macro(input: TokenStream) -> TokenStream {
     let source = input.to_string();
@@ -73,5 +76,107 @@ fn derive_query_param(ast: &syn::DeriveInput) -> quote::Tokens {
                 });
             }
         }
+    }
+}
+
+#[proc_macro_derive(FromDB, attributes(from_db))]
+pub fn sqlite_table_macro(input: TokenStream) -> TokenStream {
+    let source = input.to_string();
+
+    // Parse the string representation into a syntax tree
+    let ast = syn::parse_derive_input(&source).unwrap();
+
+    // Build the output, possibly using quasi-quotation
+    let expanded = derive_sqlite_table(&ast);
+
+    // Parse back to a token stream and return it
+    expanded.parse().unwrap()
+}
+
+fn derive_sqlite_table(ast: &syn::DeriveInput) -> quote::Tokens {
+    let (field_names, field_assignments) = match ast.body {
+        syn::Body::Struct(ref data) => {
+            if data.fields().len() == 0 {
+                panic!("#[derive(FromDB)] must have at least one field");
+            }
+
+            let mut i = 0;
+            let mut field_assignments = Vec::new();
+            let mut field_names = Vec::new();
+            for field_syn in data.fields() {
+                let field = field_syn.ident.as_ref().unwrap();
+                field_names.push(field.as_ref());
+                field_assignments.push(quote! { #field: row.get(#i) });
+                i = i + 1;
+            }
+
+            (field_names, field_assignments)
+        }
+        syn::Body::Enum(_) => panic!("#[derive(FromDB)] can only be used with structs"),
+    };
+
+    let from_db_usage = "#[from_db(\"table_name\" = \"...\")]";
+
+    let mut o_table_name = None;
+    for meta_items in ast.attrs.iter().filter_map(get_db_meta_items) {
+        for meta_item in meta_items {
+            match meta_item {
+                // Parse `#[from_db(table_name = "foo")]`
+                MetaItem(NameValue(ref name, ref lit)) if name == "table_name" => {
+                    let s = get_string_from_lit(name.as_ref(), name.as_ref(), lit);
+                    o_table_name = Some(s);
+                }
+                _ => {
+                    panic!(format!("incorrect usage of custom attribute, use: {}",
+                                   from_db_usage))
+                }
+            }
+        }
+    }
+
+    let table_name = match o_table_name {
+        Some(s) => s,
+        None => panic!(format!("must provide the table name: {}", from_db_usage)),
+    };
+
+    // Used in the quasi-quotation below as `#name`
+    let name = &ast.ident;
+
+    // Helper is provided for handling complex generic types correctly and effortlessly
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let field_query = field_names.join(", ");
+
+    let query = format!("SELECT {} FROM {} WHERE id = ?1", field_query, table_name);
+
+    quote! {
+        impl #impl_generics ::libpathfinder_common::FromDB for #name #ty_generics #where_clause {
+            fn select_one(conn: &rusqlite::Connection, id: u32) -> Result<Self, error::Error> {
+                let mut stmt = conn.prepare(#query).unwrap();
+                let s =
+                    try!(stmt.query_row(&[&id], |row| {
+                        #name { #(#field_assignments),* }
+                    }).map_err(error::Error::Rusqlite));
+
+                return Ok(s);
+            }
+        }
+    }
+}
+
+fn get_db_meta_items(attr: &syn::Attribute) -> Option<Vec<syn::NestedMetaItem>> {
+    match attr.value {
+        List(ref name, ref items) if name == "from_db" => Some(items.iter().cloned().collect()),
+        _ => None,
+    }
+}
+
+fn get_string_from_lit(attr_name: &str, meta_item_name: &str, lit: &syn::Lit) -> String {
+    if let syn::Lit::Str(ref s, _) = *lit {
+        s.clone()
+    } else {
+        panic!(format!("expected from_db {} attribute to be a string: `{} = \"...\"`",
+                       attr_name,
+                       meta_item_name));
     }
 }


### PR DESCRIPTION
This will allow use to simply:

    #[derive(FromDB)]
    #[from_db(table_name = "characters")]
    pub struct Character { ... }

for all structs we add to map to tables. The field names will have to
match the table field names, and the table_name attribute must be
accurate, but with those true, we will be able to save a lot of
duplication with the sql construction and construction of the struct
with those fields.